### PR TITLE
Fix plot() error for models without compartments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nlmixr2plot
 Title: Nonlinear Mixed Effects Models in Population PK/PD, Plot Functions
-Version: 5.0.1
+Version: 5.0.1.9000
 Authors@R: c(
     person("Matthew", "Fidler", email="matthew.fidler@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-8538-6691")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# nlmixr2plot 5.0.1.9000 (development)
+
+* Fixed an error when plotting models without compartments (#33)
+
 # nlmixr2plot 5.0.1
 
 * Updated nlmixr2 to optionally use the `tidyvpc` package

--- a/R/plot.nlmixr2.R
+++ b/R/plot.nlmixr2.R
@@ -15,7 +15,7 @@
     }
   }
   if (!.doCmt) {
-    .dat$CMT <- factor("All Data")
+    .dat$CMT <- factor(rep("All Data", nrow(.dat)), levels = "All Data")
   } else {
     levels(.dat$CMT) <- paste("Endpoint: ", levels(.dat$CMT))
   }

--- a/tests/testthat/test-plots.R
+++ b/tests/testthat/test-plots.R
@@ -145,3 +145,37 @@ test_that("test plots with vdiffr", {
     #}
   })
 })
+
+test_that("plot works for models without compartments (issue #33)", {
+  poisModel <- function() {
+    ini({
+      tlambda <- log(2)
+      eta.lambda ~ 0.1
+    })
+    model({
+      lambda <- exp(tlambda + eta.lambda)
+      DV ~ dpois(lambda)
+    })
+  }
+
+  d <- data.frame(
+    ID = rep(1:5, each = 4),
+    TIME = rep(0:3, 5),
+    DV = c(1, 2, 3, 2, 0, 1, 2, 3, 2, 1, 3, 2, 1, 2, 1, 0, 3, 2, 4, 1)
+  )
+
+  suppressMessages(
+    fit <- try(
+      nlmixr2est::nlmixr(
+        poisModel, d,
+        est = "focei",
+        control = nlmixr2est::foceiControl(print = 0, eval.max = 1, maxOuterIterations = 0)
+      ),
+      silent = TRUE
+    )
+  )
+  skip_if(inherits(fit, "try-error"))
+
+  expect_error(plotted <- plot(fit), NA)
+  expect_true("All Data" %in% names(plotted))
+})


### PR DESCRIPTION
Closes #33 

.setupPlotData filtered rows by !is.na(IRES), then assigned a 1-element factor to .dat$CMT. For likelihood-only models without compartments, IRES is missing or all-NA, yielding a 0-row data frame, and the assignment errored with "replacement has 1 row, data has 0".

Use factor(rep("All Data", nrow(.dat)), levels = "All Data") so the length matches and 0-row inputs flow through to the existing nrow > 0 guards in plotCmt() — empty fits produce an empty plot list instead of an error.

Adds a regression test using a Poisson likelihood model.

Fixes nlmixr2plot issue 33.