### PR TITLE
Remove obsolete .linCmtSensB() test guards

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nlmixr2plot
 Title: Nonlinear Mixed Effects Models in Population PK/PD, Plot Functions
-Version: 5.0.2
+Version: 5.0.2.9000
 Authors@R: c(
     person("Matthew", "Fidler", email="matthew.fidler@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-8538-6691")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# nlmixr2plot 5.0.2.9000
+
+* Removed obsolete `rxode2::.linCmtSensB()` test guards. That internal
+  was removed from `rxode2` in 2025, so the `try()`/`skip_if_not()`
+  checks always fell through and never skipped. `linCmt()` gradients are
+  now always available, so the guards are unnecessary and the tests run
+  unconditionally.
+
 # nlmixr2plot 5.0.2
 
 * Fixed an error when plotting models without compartments (#33)

--- a/tests/testthat/test-plots-cens.R
+++ b/tests/testthat/test-plots-cens.R
@@ -52,10 +52,6 @@ test_that("plot censoring", {
     cmt2m <- nlmixr2est::nlmixr(cmt2)
   )
 
-  .linS <- try(rxode2::.linCmtSensB(), silent=TRUE)
-  if (inherits(.linS, "try-error")) .linS <- TRUE
-  skip_if_not(.linS)
-
   suppressMessages(
     fit <-
       nlmixr2est::nlmixr(

--- a/tests/testthat/test-plots.R
+++ b/tests/testthat/test-plots.R
@@ -26,10 +26,6 @@ test_that("test plots with vdiffr", {
   # Set DV to LOQ for all censored items
   censData$DV[censData$CENS == 1] <-  3
 
-  .linB <- try(rxode2::.linCmtSensB(), silent=TRUE)
-  if (inherits(.linB, "try-error")) .linB <- TRUE
-  skip_if_not(.linB)
-
   suppressMessages(
     fit <-
       nlmixr2est::nlmixr(


### PR DESCRIPTION
The `R-CMD-check` / `test-coverage` failures on `main` were a segfault in
the SAEM `linCmt()` fit of `test-plots-cens.R` — an upstream SAEM-memory
bug in the dev rxode2/nlmixr2est that CI installs from GitHub `main`
(green on 2026-06-05, red on 2026-06-10). That bug has since been fixed
upstream.

This PR also removes a latent test bug. Both `test-plots-cens.R` and
`test-plots.R` gated their fits on:

```r
.lin <- try(rxode2::.linCmtSensB(), silent=TRUE)
if (inherits(.lin, "try-error")) .lin <- TRUE
skip_if_not(.lin)
```

`.linCmtSensB()` was removed from rxode2 in April 2025, so the `try()`
always errored, the fallback forced `TRUE`, and the guard never skipped.
`linCmt()` gradients are now always built in, so the guards are obsolete.
Removing them lets the tests run unconditionally and keep catching real
upstream regressions in the SAEM/FOCEi linCmt path.

Verified by building rxode2 + nlmixr2est from current `origin/main` and
running the full suite: 7 tests, 0 failures, 0 errors, 55 expectations.